### PR TITLE
add support for clojure and tomorrow night theme

### DIFF
--- a/src/lang/sunlight.clojure.js
+++ b/src/lang/sunlight.clojure.js
@@ -1,0 +1,182 @@
+(function(sunlight, undefined){
+
+  var specialForms = [
+    "def", "defmethod", "defstruct", "defrecord", "definline", "defn-", "defn", "defmacro", "deftype", "definterface", "defmulti", "defonce", "defprotocol",
+    "if", "do", "let", "quote", "var", "fn", "loop", "recur", "monitor-enter", "monitor-exit",
+    ".", "new", "set!", ".."
+  ];
+  var exceptionForms = [
+    "throw", "try", "catch", "finally"
+  ];
+  var misc = [
+    // core dynamic vars
+    "*compile-path*", "*ns*", "*print-level*", "*allow-unresolved-vars*", "*data-readers*", "*unchecked-math*",
+    "*math-context*", "*read-eval*", "*compile-files*", "*command-line-args*", "*warn-on-reflection*",
+    "*flush-on-newline*", "*out*", "*print-length*", "*file*", "*verbose-defrecords*", "*clojure-version*",
+    "*use-context-classloader*", "*err*", "*default-data-reader-fn*", "*agent*", "*print-dup*", "*print-readably*",
+    "*fn-loader*", "*print-meta*", "*in*", "*source-path*", "*compiler-options*", "*assert*", "*1", "*2", "*3", "*e",
+    // constants
+    "EMPTY_NODE", "char-escape-string", "default-data-readers", "char-name-string", "primitives-classnames"
+  ];
+  var coreForms = [
+    // general functions
+    "sorted-map", "read-line", "re-pattern", "unchecked-inc-int", "val", "find-protocol-impl",
+    "vector-of", "object-array", "max-key", "list*", "ns-aliases", "booleans", "the-ns", "==", "chunk-buffer", "longs",
+    "shorts", "format", "empty", "dorun", "remove-method", "gensym", "not=", "unchecked-multiply",
+    "bit-or", "aset-byte", "send-via", "hash-set", "->Vec", "add-watch", "unchecked-dec", "some", "boolean-array",
+    "second", "keys", "long-array", "pop-thread-bindings", "error-mode", "bit-set", "spit", "find-protocol-method",
+    "short-array", "ns-unalias", "ns-publics", "char-array", "all-ns", "long", "init-proxy", "add-classpath",
+    "await1", "short", "ns-unmap", "repeat", "zipmap", "distinct", "get-in", "bit-xor",
+    "complement", "get-validator", "ref-max-history", "promise", "set-agent-send-executor!", "-'", "pop!", "derive",
+    "aset-float", "extend", "-reset-methods", "commute", "partition-by", "rem",
+    "mapv", "filterv", "proxy-call-with-super",
+    "ns-interns", "re-matches", "split-with", "munge", "next", "deliver", "symbol", "vals", "->ArrayChunk",
+    "select-keys", "re-matcher", "rand", "deref", "unchecked-inc", "read", "sequence", "make-hierarchy", "+",
+    "assoc!", "descendants", "into-array", "last", "some-fn", "unchecked-negate",
+    "alter", "prn", "with-meta", "floats", "*", "butlast", "-",
+    "rseq", "send-off", "print", "vary-meta", "agent-error",
+    "bit-flip", "bit-and", "re-groups", "newline", "replicate", "keep-indexed",
+    "remove-ns", "xml-seq", "vec", "concat", "update-in", "vector", "with-bindings*", "conj", "bases",
+    "/", "unchecked-add", "ref-set", "assoc", "unchecked-remainder-int", "seque", "aset-char", "boolean", "read-string", "float-array",
+    "doubles", "future-call", "remove-watch", "print-str", "ref-history-count", "rsubseq",
+    "split-at", "chunk-cons", "ns-refers", "create-struct", "int-array", "unchecked-long", "float",
+    "map", "+'", "double-array", "accessor", "frequencies", "chars", "rand-int",
+    "aset-short", "unchecked-short", "prn-str", "iterate", "chunk-append", "unchecked-double", "slurp", "restart-agent",
+    "unchecked-int", "mapcat", "assoc-in", "get-thread-bindings", "ref", "conj!", "find-var", "inc", "future-cancel",
+    "every-pred", "bound-fn*", "unchecked-subtract", "ns-name", "shuffle", "re-find",
+    "bit-not", "construct-proxy", "ref-min-history", "destructure", "seq", "intern", "unchecked-multiply-int", "to-array-2d",
+    "sorted-map-by", "filter", "->VecNode", "alter-meta!", "unchecked-dec-int",
+    "key", "class", "re-seq", "-cache-protocol-fn", "test", "print-dup", "create-ns", "name", "nthrest", "aset", "nnext",
+    "doall", "extenders", "macroexpand-1", "resultset-seq", "reductions", "into",
+    "transient", "ffirst", "bit-clear", "proxy-name", "load-reader", "with-redefs-fn", "hash", "inc'",
+    "print-ctor", "drop-last", "replace", "parents", "prefers", "numerator", "quot",
+    "chunk-rest", "unchecked-negate-int", "file-seq", "send", "reverse", "count", "get-proxy-class",
+    "set", "ex-info", "unchecked-subtract-int", "comp", "nth", "byte", "dissoc!", "constantly", "load", "namespace", "pr-str",
+    "<", "rationalize", "sort-by", "->VecSeq", "cycle", "peek", "denominator", "reduce", "interleave", "cons", "macroexpand", "var-set",
+    "str", "aset-boolean", "ns-imports", "remove-all-methods", "first", "bean", "=", "memoize", "var-get", "unchecked-float", "range",
+    "tree-seq", "set-validator!", "aset-double", "*'", "unchecked-divide-int", "enumeration-seq", "prefer-method",
+    "partition-all", "ensure", "reduced", "find-ns", "struct-map", ">", "max", "proxy-mappings", "identity", "ints", "fnext",
+    "biginteger", "min-key", "reset-meta!", "push-thread-bindings", "unchecked-add-int", "subs", "compile", "agent-errors",
+    "clear-agent-errors", "printf", "ns-resolve", "method-sig", ">=", "shutdown-agents", "reduce-kv", "reset!",
+    "require", "bit-shift-left", "dec'", "methods", "compare", "sorted-set-by", "cast",
+    "namespace-munge", "supers", "pcalls", "load-string", "group-by", "get", "<=", "await", "resolve", "bytes", "print-method", "loaded-libs",
+    "fnil", "force", "partial", "pmap", "comparator", "char", "take-while", "refer", "underive", "in-ns",
+    "iterator-seq", "ancestors", "hash-combine", "persistent!", "partition", "map-indexed", "update-proxy",
+    "interpose", "chunk", "aset-int", "load-file", "apply", "swap!", "subvec",
+    "byte-array", "rest", "keyword", "ns-map", "set-error-mode!", "int", "release-pending-sends", "mod", "bigdec", "nfirst", "nthnext",
+    "aset-long", "struct", "array-map", "unchecked-char", "bigint", "dec", "println", "aget", "find-keyword", "pr", "drop", "clojure-version",
+    "eval", "aclone", "pop", "atom", "bit-shift-right",
+    "num", "disj", "merge-with", "take-nth", "double",
+    "take-last", "line-seq", "take", "unchecked-byte", "make-array", "rand-nth", "alias", "use",
+    "juxt", "alength", "chunk-first", "to-array", "hash-map", "bit-and-not",
+    "compare-and-set!", "type", "repeatedly", "trampoline", "set-error-handler!", "remove", "find", "drop-while", "not-empty",
+    "flatten", "ex-data", "set-agent-send-off-executor!", "println-str", "list", "chunk-next", "flush", "sort",
+    "dissoc", "not", "error-handler", "get-method", "agent", "sorted-set", "alter-var-root", "merge", "subseq", "min",
+    "print-simple", "bit-test", "await-for", "keep", "disj!", "meta",
+    // Predicates
+    "keyword?", "chunked-seq?", "instance?", "sequential?", "fn?", "nil?", "string?", "sorted?", "false?",
+    "true?", "odd?", "symbol?", "thread-bound?", "future-done?", "number?", "integer?", "reduced?", "reversible?",
+    "seq?", "identical?", "zero?", "char?", "distinct?", "ratio?", "neg?", "isa?", "extends?", "future?", "vector?",
+    "counted?", "class?", "special-symbol?", "var?", "empty?", "list?", "not-any?", "associative?", "float?",
+    "decimal?", "map?", "not-every?", "even?", "future-cancelled?", "bound?", "pos?", "contains?", "ifn?",
+    "delay?", "realized?", "rational?", "set?", "coll?", "every?", "satisfies?",
+    // Macros
+    "cond->>", "bound-fn", "doseq", "if-not", "letfn", "dosync", "with-open", "gen-interface", "sync", "dotimes",
+    "lazy-cat", "with-in-str", "import", "with-out-str", "when-not", "time", "for", "cond", "some->", "->>","refer-clojure", "with-loading-context", "future", "with-redefs","doto", "proxy-super", "assert", "memfn", "when-first", "pvalues",
+    "comment","ns", "with-precision","extend-type", "or", "as->", "condp", "with-local-vars", "with-bindings", "when-let", "amap", "->", "while", "case", "if-let", "extend-protocol", "and", "declare", "locking", "delay", "proxy", "reify",
+    "gen-class", "io!", "lazy-seq", "when", "areduce", "some->>", "cond->", "binding"
+  ];
+
+  if (sunlight === undefined || sunlight["registerLanguage"] === undefined) {
+    throw "Include sunlight.js before including language files";
+  }
+
+  sunlight.registerLanguage("clojure", {
+    keywords: specialForms,
+    scopes: {
+      string: [
+        [
+          "\"",
+          "\"",
+          ["\\\""]
+        ]
+      ],
+      comment: [
+        [
+          ";",
+          "\n"
+        ]
+      ],
+      regex: [
+        [
+          "#\"",
+          "\"",
+          ["\\\""]
+        ]
+      ]
+    },
+
+    identFirstLetter: /[a-zA-Z\*\+\-\!\?_]/,
+    identAfterFirstLetter: /[^\s\,#%&()\[\]{}]/,
+
+    customTokens: {
+      'named-ident': {
+        values: coreForms,
+        boundary: "[\\s\\(\\),{}\\[\\]]"
+      },
+      constant: {
+        values: misc,
+        boundary: "[\\s\\(\\),{}\\[\\]]"
+      },
+      variable: {
+        values: exceptionForms,
+        boundary: "[\\s\\(\\),{}\\[\\]]",
+      },
+      boolean: {
+        values: ["true", "false"],
+        boundary: "[\\s\\(\\),{}\\[\\]]",
+      }
+    },
+    customParseRules: [
+      // characters
+      function(context) {
+        if (context.reader.current() !== "\\") {
+          return null;
+        }
+        var charNameStrings = ["\\space", "\\backspace", "\\tab", "\\newline", "\\formfeed", "\\return"];
+        var map = sunlight.util.createHashMap(charNameStrings, "\\b", false);
+        var tok = sunlight.util.matchWord(context, map, "char", false);
+
+        if (tok !== null) {
+          return tok;
+        } else {
+          var value = "\\" + context.reader.read(1);
+          var line = context.reader.getLine();
+          var column = context.reader.getColumn();
+          return context.createToken("char", value, line, column);
+        }
+      },
+      // keywords
+      function(context) {
+        if(context.reader.current() !== ":") {
+          return null;
+        }
+        var value = /^:[^\s(){}\[\],]+/.exec(context.reader.substring())[0];
+        var tok =  context.createToken("symbol", value, context.reader.getLine(), context.reader.getColumn());
+        context.reader.read(value.length - 1);
+        return tok;
+      },
+
+    ],
+
+  caseInsensitive: false,
+
+    doNotParse: /\s/,
+
+    contextItems: {
+      userDefinedFunctions: []
+    },
+
+    operators: []
+  });
+}(this["Sunlight"]));

--- a/src/themes/sunlight.tomorrow-night.css
+++ b/src/themes/sunlight.tomorrow-night.css
@@ -1,0 +1,296 @@
+/* global styles */
+.sunlight-container {
+	clear: both !important;
+	position: relative !important;
+	margin: 10px 0 !important;
+}
+.sunlight-code-container {
+	clear: both !important;
+	position: relative !important;
+	border: none;
+	border-color: #626262 !important;
+	background-color: #1d1f21 !important;
+}
+.sunlight-highlighted, .sunlight-container, .sunlight-container textarea, .sunlight-container pre {
+  font-family: "Liberation Mono", "DejaVu Sans Mono", Monaco, monospace;
+	font-size: 12px !important;
+	line-height: 15px !important;
+}
+.sunlight-highlighted, .sunlight-container textarea {
+	color: #FFFFFF !important;
+	margin: 0 !important;
+}
+.sunlight-container textarea {
+	padding-left: 0 !important;
+	margin-left: 0 !important;
+	margin-right: 0 !important;
+	padding-right: 0 !important;
+}
+.sunlight-code-container > .sunlight-highlighted {
+	white-space: pre;
+	overflow-x: auto;
+	overflow-y: hidden; /* ie requires this wtf? */
+}
+.sunlight-highlighted {
+	z-index: 1;
+	position: relative;
+}
+.sunlight-highlighted * {
+	background: transparent;
+}
+.sunlight-line-number-margin {
+	float: left !important;
+	margin-right: 5px !important;
+	margin-top: 0 !important;
+	margin-bottom: 0 !important;
+	padding: 0 !important;
+	padding-right: 4px !important;
+	padding-left: 4px !important;
+	border-right: 1px solid #9A9A9A !important;
+	background-color: #3E3E3E !important;
+	color: #9A9A9A !important;
+	text-align: right !important;
+	position: relative;
+	z-index: 3;
+}
+.sunlight-highlighted a, .sunlight-line-number-margin a {
+	border: none !important;
+	text-decoration: none !important;
+	font-style: normal !important;
+	padding: 0 !important;
+}
+.sunlight-line-number-margin a {
+	color: inherit !important;
+}
+.sunlight-line-highlight-overlay {
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 100%;
+	z-index: 0;
+}
+.sunlight-line-highlight-overlay div {
+	height: 15px;
+	width: 100%;
+}
+.sunlight-line-highlight-overlay .sunlight-line-highlight-active {
+	background-color: #282a2e;
+}
+
+/* menu */
+.sunlight-menu {
+	background-color: #FFFFCC;
+	color: #000000;
+}
+.sunlight-menu ul {
+	margin: 0 !important;
+	padding: 0 !important;
+	list-style-type: none !important;
+}
+.sunlight-menu li {
+	float: right !important;
+	margin-left: 5px !important;
+}
+.sunlight-menu a, .sunlight-menu img {
+	color: #000099 !important;
+	text-decoration: none !important;
+	border: none !important;
+}
+
+.sunlight-string,
+.sunlight-regex,
+.sunlight-heredoc,
+.sunlight-heredocDeclaration,
+.sunlight-nowdoc,
+.sunlight-longString,
+.sunlight-rawString,
+.sunlight-binaryString,
+.sunlight-verbatimString,
+.sunlight-rawLongString,
+.sunlight-binaryLongString,
+.sunlight-diff .sunlight-added,
+.sunlight-scala .sunlight-symbolLiteral {
+  color: #b5bd68 !important;
+}
+.sunlight-operator,
+.sunlight-punctuation,
+.sunlight-delimiter {
+  color: #8abeb7 !important;
+}
+.sunlight-ident,
+.sunlight-diff .sunlight-unchanged {
+  color: #c5c8c6 !important;
+}
+.sunlight-comment,
+.sunlight-xmlDocCommentContent,
+.sunlight-nginx .sunlight-ssiCommand,
+.sunlight-sln .sunlight-formatDeclaration,
+.sunlight-diff .sunlight-mergeHeader,
+.sunlight-diff .sunlight-noNewLine {
+  color: #969896 !important;
+}
+.sunlight-number,
+.sunlight-char,
+.sunlight-boolean,
+.sunlight-cdata,
+.sunlight-guid,
+.sunlight-diff .sunlight-modified {
+  color: #de935f !important;
+}
+.sunlight-constant
+{
+  color: #f0c674 !important;
+}
+.sunlight-named-ident,
+.sunlight-xml .sunlight-attribute,
+.sunlight-javascript .sunlight-globalVariable,
+.sunlight-globalObject,
+.sunlight-css .sunlight-id,
+.sunlight-python .sunlight-attribute,
+.sunlight-nginx .sunlight-context,
+.sunlight-httpd .sunlight-context,
+.sunlight-lisp .sunlight-declarationSpecifier,
+.sunlight-erlang .sunlight-userDefinedFunction,
+.sunlight-diff .sunlight-removed {
+  color: #81a2be !important;
+}
+.sunlight-keyword,
+.sunlight-languageConstruct,
+.sunlight-specialOperator,
+.sunlight-xml .sunlight-tagName,
+.sunlight-xml .sunlight-operator,
+.sunlight-bash .sunlight-command,
+.sunlight-erlang .sunlight-moduleAttribute {
+  color: #b294bb !important;
+}
+.sunlight-shortOpenTag,
+.sunlight-openTag,
+.sunlight-closeTag,
+.sunlight-xmlOpenTag,
+.sunlight-xmlCloseTag,
+.sunlight-aspOpenTag,
+.sunlight-aspCloseTag,
+.sunlight-label,
+.sunlight-css .sunlight-importantFlag {
+  background-color: #7373C1 !important;
+}
+.sunlight-content {
+  color: #FFFFFF !important;
+  font-weight: bold !important;
+}
+.sunlight-function,
+.sunlight-globalFunction,
+.sunlight-objective-c .sunlight-messageDestination,
+.sunlight-ruby .sunlight-specialFunction,
+.sunlight-clojure .sunlight-specialVariable,
+.sunlight-6502asm .sunlight-illegalOpcode,
+.sunlight-powershell .sunlight-switch,
+.sunlight-lisp .sunlight-macro,
+.sunlight-lisp .sunlight-specialForm,
+.sunlight-lisp .sunlight-type,
+.sunlight-sln .sunlight-sectionName,
+.sunlight-diff .sunlight-header {
+  color: #f0c674 !important;
+}
+.sunlight-variable,
+.sunlight-environmentVariable,
+.sunlight-specialVariable,
+.sunlight-objective-c .sunlight-messageArgumentName,
+.sunlight-lisp .sunlight-globalVariable,
+.sunlight-ruby .sunlight-globalVariable,
+.sunlight-ruby .sunlight-instanceVariable {
+  color: #cc6666 !important;
+}
+.sunlight-regexLiteral,
+.sunlight-lisp .sunlight-operator,
+.sunlight-6502asm .sunlight-pseudoOp,
+.sunlight-erlang .sunlight-macro,
+.sunlight-diff .sunlight-rangeInfo {
+  color: #8abeb7 !important;
+}
+.sunlight-specialVariable {
+  font-style: italic !important;
+  font-weight: bold !important;
+}
+.sunlight-csharp .sunlight-pragma,
+.sunlight-preprocessorDirective,
+.sunlight-vb .sunlight-compilerDirective {
+  color: #666363 !important;
+  font-style: italic !important;
+}
+.sunlight-xmlDocCommentMeta,
+.sunlight-java .sunlight-annotation,
+.sunlight-scala .sunlight-annotation,
+.sunlight-docComment {
+  color: #666363 !important;
+}
+.sunlight-quotedIdent,
+.sunlight-ruby .sunlight-subshellCommand,
+.sunlight-lisp .sunlight-keywordArgument,
+.sunlight-haskell .sunlight-infixOperator,
+.sunlight-erlang .sunlight-quotedAtom {
+  color: #F8CA16 !important;
+}
+
+
+
+
+/* html/xml */
+.sunlight-xml .sunlight-tagName,
+.sunlight-xml .sunlight-operator,
+.sunlight-xml .sunlight-attribute {
+	font-weight: normal !important;
+}
+.sunlight-doctype {
+	color: #DEB9B2 !important;
+	font-style: italic !important;
+}
+.sunlight-xml .sunlight-entity {
+	background-color: #E6E585 !important;
+	color: #000000 !important;
+}
+
+/* javascript */
+.sunlight-javascript .sunlight-reservedWord {
+	font-style: italic !important;
+}
+
+/* css */
+.sunlight-css .sunlight-element {
+	color: #E9EE97 !important;
+}
+.sunlight-css .sunlight-microsoftFilterPrefix {
+	color: #C9FF9F !important;
+}
+.sunlight-css .sunlight-rule {
+	color: #0099FF !important;
+}
+.sunlight-css .sunlight-class {
+	color: #E78282 !important;
+}
+.sunlight-css .sunlight-pseudoClass, .sunlight-css .sunlight-pseudoElement {
+	color: #73D693 !important;
+}
+
+/* bash */
+.sunlight-bash .sunlight-hashBang {
+	color: #FFFF00 !important;
+}
+
+.sunlight-bash .sunlight-verbatimCommand {
+	color: #BBA4EE !important;
+}
+.sunlight-bash .sunlight-variable,
+.sunlight-bash .sunlight-specialVariable {
+	color: #ED8585 !important;
+}
+
+/* python */
+.sunlight-python .sunlight-specialMethod {
+	font-weight: bold !important;
+	color: #B0A3C2;
+}
+
+.sunlight-symbol { 
+  color: #b5bd68 !important;
+}


### PR DESCRIPTION
Hi,

I have added a clojure language definition file and added the tomorrow-night theme. I copied and adjusted the dark theme a bit. The theme is a tailored to display the clojure code nicely, but it should look fine for other languages too.
