### PR TITLE
Treat ids with double primes correctly (fixes #11)

### DIFF
--- a/src/lang/sunlight.haskell.js
+++ b/src/lang/sunlight.haskell.js
@@ -20,7 +20,7 @@
 					line = context.reader.getLine(), 
 					column = context.reader.getColumn();
 					
-				if (context.reader.current() !== "'" && peek !== "'") {
+				if (context.reader.current() !== "'") {
 					return null;
 				}
 				

--- a/tests/test-haskell.html
+++ b/tests/test-haskell.html
@@ -1000,6 +1000,19 @@ spaces n | n &lt;= 0    = &quot;&quot;
    (TextDetails_Chr 'a') 1 Doc_Empty))))))))))) (Doc_NilAbove (Doc_Nest
 -}
 
+-- Extra code to test identifiers with single quotes in them.
+-- Only 'c' should be highlighted as a character literal,
+-- the rest are legal identifiers.
+
+c :: Char
+c = c'
+  where c' = c''
+        c'' = c'''
+        c''' = c'c'
+        c'c' = c'c''
+        c'c'' = c''c''
+        c''c'' = 'c'
+
 </pre>
 	</body>
 


### PR DESCRIPTION
Do not highlight identifiers with double primes as character literals in Haskell. The bug seems to be in an extra condition that checks if we are at the beginning of a character literal. The test file for Haskell looks fine after this change.
